### PR TITLE
Use SPDX license tags

### DIFF
--- a/src/algorithms.c
+++ b/src/algorithms.c
@@ -1,20 +1,6 @@
 /*
-	Copyright (C) 2022-current Valasiadis Fotios
-
-    This library is free software; you can redistribute it and/or
-    modify it under the terms of the GNU Lesser General Public
-    License as published by the Free Software Foundation; either
-    version 2.1 of the License, or (at your option) any later version.
-
-    This library is distributed in the hope that it will be useful,
-    but WITHOUT ANY WARRANTY; without even the implied warranty of
-    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-    Lesser General Public License for more details.
-
-    You should have received a copy of the GNU Lesser General Public
-    License along with this library; if not, write to the Free Software
-    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301
-    USA
+	Copyright (C) 2022 Valasiadis Fotios
+	SPDX-License-Identifier: LGPL-2.1-or-later
 */
 
 

--- a/src/algorithms.h
+++ b/src/algorithms.h
@@ -1,21 +1,8 @@
 /*
-	Copyright (C) 2022-current Valasiadis Fotios
-
-    This library is free software; you can redistribute it and/or
-    modify it under the terms of the GNU Lesser General Public
-    License as published by the Free Software Foundation; either
-    version 2.1 of the License, or (at your option) any later version.
-
-    This library is distributed in the hope that it will be useful,
-    but WITHOUT ANY WARRANTY; without even the implied warranty of
-    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-    Lesser General Public License for more details.
-
-    You should have received a copy of the GNU Lesser General Public
-    License along with this library; if not, write to the Free Software
-    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301
-    USA
+	Copyright (C) 2022 Valasiadis Fotios
+	SPDX-License-Identifier: LGPL-2.1-or-later
 */
+
 #pragma once
 
 

--- a/src/main.c
+++ b/src/main.c
@@ -1,20 +1,6 @@
 /*
-	Copyright (C) 2022-current Valasiadis Fotios
-
-    This library is free software; you can redistribute it and/or
-    modify it under the terms of the GNU Lesser General Public
-    License as published by the Free Software Foundation; either
-    version 2.1 of the License, or (at your option) any later version.
-
-    This library is distributed in the hope that it will be useful,
-    but WITHOUT ANY WARRANTY; without even the implied warranty of
-    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-    Lesser General Public License for more details.
-
-    You should have received a copy of the GNU Lesser General Public
-    License along with this library; if not, write to the Free Software
-    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301
-    USA
+	Copyright (C) 2022 Valasiadis Fotios
+	SPDX-License-Identifier: LGPL-2.1-or-later
 */
 
 #include <stdio.h>

--- a/src/tracer.c
+++ b/src/tracer.c
@@ -1,20 +1,6 @@
 /*
-	Copyright (C) 2022-current Valasiadis Fotios
-
-    This library is free software; you can redistribute it and/or
-    modify it under the terms of the GNU Lesser General Public
-    License as published by the Free Software Foundation; either
-    version 2.1 of the License, or (at your option) any later version.
-
-    This library is distributed in the hope that it will be useful,
-    but WITHOUT ANY WARRANTY; without even the implied warranty of
-    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-    Lesser General Public License for more details.
-
-    You should have received a copy of the GNU Lesser General Public
-    License along with this library; if not, write to the Free Software
-    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301
-    USA
+	Copyright (C) 2022 Valasiadis Fotios
+	SPDX-License-Identifier: LGPL-2.1-or-later
 */
 
 #include <stdio.h>

--- a/src/tracer.h
+++ b/src/tracer.h
@@ -1,20 +1,6 @@
 /*
-	Copyright (C) 2022-current Valasiadis Fotios
-
-    This library is free software; you can redistribute it and/or
-    modify it under the terms of the GNU Lesser General Public
-    License as published by the Free Software Foundation; either
-    version 2.1 of the License, or (at your option) any later version.
-
-    This library is distributed in the hope that it will be useful,
-    but WITHOUT ANY WARRANTY; without even the implied warranty of
-    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-    Lesser General Public License for more details.
-
-    You should have received a copy of the GNU Lesser General Public
-    License along with this library; if not, write to the Free Software
-    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301
-    USA
+	Copyright (C) 2022 Valasiadis Fotios
+	SPDX-License-Identifier: LGPL-2.1-or-later
 */
 
 #pragma once


### PR DESCRIPTION
- Use single-line SPDX license tag instead of text
- Fix copyright attribution by deleting "current"

Fixes #5

Signed-off-by: Alexios Zavras <github@zvr.gr>
