### PR TITLE
Store path strings in vector

### DIFF
--- a/src/tracer.c
+++ b/src/tracer.c
@@ -61,6 +61,7 @@ read_str_from_process(char *addr, pid_t pid)
 {
     struct vector_long buffer;
     vector_long_new(&buffer);
+    vector_long_reserve(&buffer, 16 / sizeof(long));
     
     do
     {

--- a/src/tracer.c
+++ b/src/tracer.c
@@ -56,11 +56,13 @@ has_end_of_str(const char *buffer, size_t size)
 /*
     addr is an address pointing to the tracee process' address space, thus we need to copy it.
 */
-static const char *
+static char *
 read_str_from_process(char *addr, pid_t pid)
 {
     struct vector_long buffer;
-    const char *cbuffer = (char *) buffer.arr;	// For readability
+    vector_long_new(&buffer);
+
+    char *cbuffer = (char *) buffer.arr;	// For readability
     
     do
     {
@@ -92,7 +94,7 @@ handle_syscall(pid_t pid, const struct ptrace_syscall_info *entry,
 	f.path = read_str_from_process((char *) entry->entry.args[1], pid);
     }
 
-    vector_file_push_back(buffer->files, &f);
+    vector_file_push_back(&buffer->files, &f);
 }
 
 static int

--- a/src/tracer.c
+++ b/src/tracer.c
@@ -61,17 +61,15 @@ read_str_from_process(char *addr, pid_t pid)
 {
     struct vector_long buffer;
     vector_long_new(&buffer);
-
-    char *cbuffer = (char *) buffer.arr;	// For readability
     
     do
     {
 	long bytes =
 		ptrace(PTRACE_PEEKDATA, pid, addr + buffer.size * sizeof (long), NULL);
 	vector_long_push_back(&buffer, &bytes);
-    } while (!has_end_of_str(cbuffer + buffer.size * sizeof (long), sizeof (long)));
+    } while (!has_end_of_str((char *) (buffer.arr + buffer.size - 1), sizeof (long)));
 
-    return cbuffer;
+    return (char *) buffer.arr;
 }
 
 static void


### PR DESCRIPTION
Got rid of the static buffer and now instead using the dynamic vector. As a result the program consumes less memory and actually has no limit to how big the path string can be.