### PR TITLE
identifier declarations

### DIFF
--- a/.indent.pro
+++ b/.indent.pro
@@ -48,6 +48,8 @@
 --tab-size8
 --use-tabs
 
+-di1
+
 /* commonly used types */
 -TFILE
 -Tcomparison_fn_t


### PR DESCRIPTION
by default indent will line up identifiers, would prefer if they were placed in the first available position instead