### PR TITLE
RDF first steps

### DIFF
--- a/doc/output.md
+++ b/doc/output.md
@@ -1,0 +1,89 @@
+# build-recorder output format
+
+Each run of `build-recorder` generates a single output file.
+
+The information is represented in RDF triples,
+saved in Turtle format.
+
+## Ontology
+
+The special types and predicates used are listed below:
+
+### Types
+
+#### Process
+- pid: the process id
+- cmd: the actual command line (concatenation of all arguments separated by white space)
+- start: timestamp
+- end: timestamp
+
+#### File
+- name: the file name
+- size: the file size, in bytes
+- hash: a hexadecimal string of a unique, git-compatible, hash of the content of the file
+
+
+### Relationships
+
+#### execs
+- Domain: Process
+- Range: Process
+
+#### reads
+- Domain: Process
+- Range: File
+
+#### writes
+- Domain: Process
+- Range: File
+
+
+## Example
+
+The example below is fictional
+and is only to be used to represent typical uses.
+
+The example is about a fictional compiler (`compile`),
+called to compile a single file (`foo.c`).
+The compiler calls a preprocesor (`preprocess`)
+to generate a temporary file (`tmp.c`)
+and then generate the object code in (`foo.o`)
+
+```
+pid1	a	process .
+pid1	cmd	"compile -o foo.c" .
+pid1	start	20220804T100000 .
+
+pid2	a	process .
+pid2	cmd	"preprocess foo.c tmp.c"
+pid2	start	20220804T100000 .
+
+pid1	execs	pid2 .
+
+f1	a	file .
+f1	name	"foo.c" .
+f1	size	100 .
+f1	hash	"0000000000000000000000000000000000000000" .
+
+f2	a	file .
+f2	name	"tmp.c" .
+f2	size	888 .
+f2	hash	"1111111111111111111111111111111111111111" .
+
+pid2	reads	f1 .
+pid2	writes	f2 .
+
+pid3	a	process .
+pid3	cmd	"c2o tmp.c foo.o" .
+
+pid1	execs	pid3 .
+pid3	reads	f2 .
+
+f3	a	file .
+f3	name	"foo.o" .
+f3	size	444 .
+f3	hash	"2222222222222222222222222222222222222222" .
+
+pid3	writes	f3 .
+
+```

--- a/src/record.c
+++ b/src/record.c
@@ -1,0 +1,73 @@
+
+/*
+Copyright 2022 Alexios Zavras
+SPDX-License-Identifier: LGPL-2.1-or-later
+*/
+
+#include	"config.h"
+
+#include	"types.h"
+#include	"record.h"
+
+#include	<stdio.h>
+#include	<time.h>
+
+FILE *fout;
+
+void
+record_start(char *fname)
+{
+    fout = fopen(fname, "w");
+
+    fprintf(fout,
+	    "@base <http://example.org/> .\n"
+	    "@prefix b:  <http://example.org/build-recorder#> .\n"
+	    "@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .\n"
+	    "@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .\n");
+}
+
+static void
+record_triple(char *s, char *p, char *o)
+{
+    fprintf(fout, "%s\t%s\t%s .\n", s, p, o);
+}
+
+static void
+timestamp_now(char *s, size_t sz)
+{
+    time_t now;
+
+    time(&now);
+    strftime(s, sz, "%FT%TZ", gmtime(&now));
+}
+
+void
+record_process_start(pid_t pid, char *cmd_line)
+{
+    char pbuf[32];
+    char tbuf[32];
+
+    sprintf(pbuf, "pid%ld", (long) pid);
+    timestamp_now(tbuf, 32);
+
+    record_triple(pbuf, "a", "b:process");
+    record_triple(pbuf, "b:cmd", cmd_line);
+    record_triple(pbuf, "b:start", tbuf);
+}
+
+void
+record_process_end(pid_t pid)
+{
+    char pbuf[32];
+    char tbuf[32];
+
+    sprintf(pbuf, "pid%ld", (long) pid);
+    timestamp_now(tbuf, 32);
+
+    record_triple(pbuf, "b:end", tbuf);
+}
+
+void
+record_fileuse(pid_t pid, char *path, int purpose, uint8_t hash)
+{
+}

--- a/src/record.h
+++ b/src/record.h
@@ -1,0 +1,6 @@
+
+/* record.c */
+void record_start(char *fname);
+void record_process_start(pid_t pid, char *cmd_line);
+void record_process_end(pid_t pid);
+void record_fileuse(pid_t pid, char *path, int purpose, uint8_t hash);

--- a/src/types.h
+++ b/src/types.h
@@ -10,6 +10,7 @@ SPDX-License-Identifier: LGPL-2.1-or-later
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <fcntl.h>
+#include <stdint.h>
 #include <unistd.h>
 
 #include <sys/ptrace.h>
@@ -23,9 +24,9 @@ SPDX-License-Identifier: LGPL-2.1-or-later
  * Not all info is added at the same time.
  */
 typedef struct {
-    char           *path;
-    int             purpose;
-    uint8_t        *hash;
+    char *path;
+    int purpose;
+    uint8_t *hash;
 } FILE_INFO;
 
 /*
@@ -37,10 +38,10 @@ typedef struct {
  * stop info struct.
  */
 typedef struct {
-    pid_t           pid;
-    char           *cmd_line;
-    int             numfinfo;
-    FILE_INFO      *finfo;
-    int             finfo_size;
+    pid_t pid;
+    char *cmd_line;
+    int numfinfo;
+    FILE_INFO *finfo;
+    int finfo_size;
     struct ptrace_syscall_info state;
 } PROCESS_INFO;

--- a/src/types.h
+++ b/src/types.h
@@ -14,6 +14,7 @@ SPDX-License-Identifier: LGPL-2.1-or-later
 #include <unistd.h>
 
 #include <sys/ptrace.h>
+#include        <linux/ptrace.h>
 
 /*
  * For each file, we keep its name/path


### PR DESCRIPTION
- openat(2) now handled properly
- autoconf now links with libcrypto
- requested changes
- indent
- added autoconf checks
- headers now in a single lexicographical ordered list
- removed open_files, now each file with a file descriptor "fd" is placed at finfo[fd] array index
- indent
- fixed bug where ARM autoconf wouldn't accept multiline checks without m4_normalize
- Add first pass of description of output format
- Fix missing include for uint8_t type
- Add another missing header (for ptrace_syscall_info)
- Add prototypes of recording functions
