### PR TITLE
Use nonpointer instead

### DIFF
--- a/src/record.c
+++ b/src/record.c
@@ -67,6 +67,6 @@ record_process_end(pid_t pid)
 }
 
 void
-record_fileuse(pid_t pid, char *path, int purpose, uint8_t *hash)
+record_fileuse(pid_t pid, char *path, int purpose, uint8_t hash)
 {
 }

--- a/src/record.h
+++ b/src/record.h
@@ -5,4 +5,4 @@
 void record_start(char *fname);
 void record_process_start(pid_t pid, char *cmd_line);
 void record_process_end(pid_t pid);
-void record_fileuse(pid_t pid, char *path, int purpose, uint8_t *hash);
+void record_fileuse(pid_t pid, char *path, int purpose, uint8_t hash);


### PR DESCRIPTION
Accidentaly made the hash parameter a pointer, it doesn't have to be.