### PR TITLE
Handle zerolength files

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -10,5 +10,6 @@ bin_PROGRAMS = build_recorder
 build_recorder_SOURCES = \
     src/tracer.c \
     src/hash.c \
+    src/record.c \
     src/main.c
 

--- a/src/hash.c
+++ b/src/hash.c
@@ -28,13 +28,13 @@ SPDX-License-Identifier: LGPL-2.1-or-later
 #define SHA1_HEXBUF_LEN (2 * SHA1_OUTPUT_LEN + 1)
 
 typedef uint8_t hashsig[SHA1_OUTPUT_LEN];
-typedef char    hashstr[SHA1_HEXBUF_LEN];
+typedef char hashstr[SHA1_HEXBUF_LEN];
 
-char           *
+char *
 hash_to_str(uint8_t *h)
 {
-    char           *hash;
-    char           *ph;
+    char *hash;
+    char *ph;
 
     ph = hash = malloc(SHA1_HEXBUF_LEN);
     if (hash == NULL) {
@@ -50,11 +50,11 @@ hash_to_str(uint8_t *h)
     return hash;
 }
 
-uint8_t        *
+uint8_t *
 hash_str(char *str, off_t strsize)
 {
-    SHA_CTX         ctx;
-    unsigned char  *hash;
+    SHA_CTX ctx;
+    unsigned char *hash;
 
     hash = malloc(SHA1_OUTPUT_LEN);
     if (hash == NULL) {
@@ -69,34 +69,15 @@ hash_str(char *str, off_t strsize)
     return hash;
 }
 
-uint8_t        *
+uint8_t *
 hash_file_contents(char *name, off_t sz)
 {
-    int             fd = open(name, O_RDONLY);
-
-    if (fd < 0) {
-	error(0, errno, "open `%s'", name);
-	return NULL;
-    }
-    char           *buf = mmap(NULL, sz, PROT_READ, MAP_PRIVATE, fd, 0);
-
-    if (buf == MAP_FAILED) {
-	error(0, errno, "mmaping `%s'", name);
-	return NULL;
-    }
-    int             ret = madvise(buf, sz, MADV_SEQUENTIAL);
-
-    if (ret) {
-	error(0, errno, "madvise `%s'", name);
-    }
-
-    char            pre[32];
-    int             presize;
+    char pre[32];
+    int presize;
+    unsigned char *hash;
+    SHA_CTX ctx;
 
     presize = sprintf(pre, "blob %ld%c", sz, 0);
-
-    SHA_CTX         ctx;
-    unsigned char  *hash;
 
     hash = malloc(SHA1_OUTPUT_LEN);
     if (hash == NULL) {
@@ -106,18 +87,42 @@ hash_file_contents(char *name, off_t sz)
 
     SHA1_Init(&ctx);
     SHA1_Update(&ctx, pre, presize);
-    SHA1_Update(&ctx, buf, sz);
-    SHA1_Final(hash, &ctx);
 
-    close(fd);
+    if (sz) {
+	int fd = open(name, O_RDONLY);
+
+	if (fd < 0) {
+	    error(0, errno, "open `%s'", name);
+	    return NULL;
+	}
+	char *buf = mmap(NULL, sz, PROT_READ, MAP_PRIVATE, fd, 0);
+
+	if (buf == MAP_FAILED) {
+	    error(0, errno, "mmaping `%s'", name);
+	    return NULL;
+	}
+	int ret = madvise(buf, sz, MADV_SEQUENTIAL);
+
+	if (ret) {
+	    error(0, errno, "madvise `%s'", name);
+	}
+
+	SHA1_Update(&ctx, buf, sz);
+	SHA1_Final(hash, &ctx);
+
+	close(fd);
+    } else {
+	SHA1_Update(&ctx, NULL, sz);
+	SHA1_Final(hash, &ctx);
+    }
 
     return hash;
 }
 
-uint8_t        *
+uint8_t *
 hash_file(char *fname)
 {
-    struct stat     fstat;
+    struct stat fstat;
 
     if (stat(fname, &fstat)) {
 	error(0, errno, "getting info on `%s'", fname);


### PR DESCRIPTION
Now skips mmap and madvice on empty files and instead directly computes the hash value of empty strings. Closes #28 