### PR TITLE
Handle null paths

### DIFF
--- a/src/tracer.c
+++ b/src/tracer.c
@@ -203,15 +203,10 @@ handle_syscall(pid_t pid, const struct ptrace_syscall_info *entry,
 
 	    finfo = find(pid)->finfo + fd;
 
-<<<<<<< HEAD
-	    if(finfo->path != (char *) 0) {
-		finfo->hash = hash_file(finfo->path);
+	    if (finfo->path != (char *) 0) {
+		finfo->hash = get_file_hash(finfo->path);
 		record_fileuse(pid, finfo->path, finfo->purpose, finfo->hash);
 	    }
-=======
-	    finfo->hash = get_file_hash(finfo->path);
-	    record_fileuse(pid, finfo->path, finfo->purpose, finfo->hash);
->>>>>>> main
 	    break;
 	default:
 	    return;

--- a/src/tracer.c
+++ b/src/tracer.c
@@ -205,8 +205,10 @@ handle_syscall(pid_t pid, const struct ptrace_syscall_info *entry,
 
 	    finfo = find(pid)->finfo + fd;
 
-	    finfo->hash = hash_file(finfo->path);
-	    record_fileuse(pid, finfo->path, finfo->purpose, finfo->hash);
+	    if(finfo->path != (char *) 0) {
+		finfo->hash = hash_file(finfo->path);
+		record_fileuse(pid, finfo->path, finfo->purpose, finfo->hash);
+	    }
 	    break;
 	default:
 	    return;


### PR DESCRIPTION
Now ignores `FILE_INFO`s that aren't associated with any traced opened file. Closes #47 