### PR TITLE
hash update

### DIFF
--- a/src/hash.c
+++ b/src/hash.c
@@ -31,9 +31,6 @@ SPDX-License-Identifier: LGPL-2.1-or-later
 
 #include	"hash.h"
 
-typedef uint8_t hashsig[SHA1_OUTPUT_LEN];
-typedef char hashstr[SHA1_HEXBUF_LEN];
-
 static char *
 hash_to_str(uint8_t *h)
 {

--- a/src/hash.h
+++ b/src/hash.h
@@ -1,0 +1,3 @@
+
+/* hash.c */
+char *get_file_hash(char *fname);

--- a/src/record.c
+++ b/src/record.c
@@ -67,6 +67,6 @@ record_process_end(pid_t pid)
 }
 
 void
-record_fileuse(pid_t pid, char *path, int purpose, uint8_t *hash)
+record_fileuse(pid_t pid, char *path, int purpose, char *hash)
 {
 }

--- a/src/record.h
+++ b/src/record.h
@@ -1,7 +1,6 @@
-#include <sys/types.h> // pid_t
-#include <stdint.h> // uint8_t
+#include <sys/types.h>		       // pid_t
 
 void record_start(char *fname);
 void record_process_start(pid_t pid, char *cmd_line);
 void record_process_end(pid_t pid);
-void record_fileuse(pid_t pid, char *path, int purpose, uint8_t *hash);
+void record_fileuse(pid_t pid, char *path, int purpose, char *hash);

--- a/src/tracer.c
+++ b/src/tracer.c
@@ -10,7 +10,6 @@ SPDX-License-Identifier: LGPL-2.1-or-later
 #include	<errno.h>
 #include	<error.h>
 #include	<limits.h>
-#include	<stdint.h>
 #include	<stdlib.h>
 #include	<string.h>
 #include	<unistd.h>
@@ -23,6 +22,7 @@ SPDX-License-Identifier: LGPL-2.1-or-later
 #include	<sys/wait.h>
 
 #include	"types.h"
+#include	"hash.h"
 #include	"record.h"
 
 /*
@@ -128,8 +128,6 @@ find(pid_t pid)
     return pinfo + i;
 }
 
-uint8_t *hash_file(char *);
-
 static void
 handle_syscall(pid_t pid, const struct ptrace_syscall_info *entry,
 	       const struct ptrace_syscall_info *exit)
@@ -205,7 +203,7 @@ handle_syscall(pid_t pid, const struct ptrace_syscall_info *entry,
 
 	    finfo = find(pid)->finfo + fd;
 
-	    finfo->hash = hash_file(finfo->path);
+	    finfo->hash = get_file_hash(finfo->path);
 	    record_fileuse(pid, finfo->path, finfo->purpose, finfo->hash);
 	    break;
 	default:

--- a/src/types.h
+++ b/src/types.h
@@ -10,7 +10,6 @@ SPDX-License-Identifier: LGPL-2.1-or-later
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <fcntl.h>
-#include <stdint.h>
 #include <unistd.h>
 
 #include <sys/ptrace.h>
@@ -27,7 +26,7 @@ SPDX-License-Identifier: LGPL-2.1-or-later
 typedef struct {
     char *path;
     int purpose;
-    uint8_t *hash;
+    char *hash;
 } FILE_INFO;
 
 /*


### PR DESCRIPTION
- openat(2) now handled properly
- autoconf now links with libcrypto
- requested changes
- indent
- added autoconf checks
- headers now in a single lexicographical ordered list
- removed open_files, now each file with a file descriptor "fd" is placed at finfo[fd] array index
- indent
- fixed bug where ARM autoconf wouldn't accept multiline checks without m4_normalize
- Add first pass of description of output format
- Fix missing include for uint8_t type
- Add another missing header (for ptrace_syscall_info)
- Add prototypes of recording functions
- we shouldn't rely on include order, that's a recipe for disaster
- Instead of having 3 parameters, take a convenient FILE_INFO structure. More readable, better performance(we don't need to copy)
- now includes sys/types.h instead of types.h
- shouldn't use FILE_INFO, it's a separate module
- creat is now handled properly
- no longer throws an error if more than 1024 files are open concurrently
- handle_syscall(3) is now organized
- inlined handlers, added pid in record_file
- helped indent, now uses record_fileuse
- help indent with comments
- added record.c in sources
- Simplify hashing, also handling zero-length files
- Change hash type to `char *`
