### PR TITLE
Trace pstart

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -52,7 +52,10 @@ AC_CHECK_TYPES(m4_normalize([
 
 AC_CHECK_TYPE([SHA_CTX],,, [#include <openssl/sha.h>])
 
-AC_CHECK_DECL([PATH_MAX],,, [#include <limits.h>])
+AC_CHECK_DECLS(m4_normalize([
+	PATH_MAX,
+	ARG_MAX
+]),,, [#include <linux/limits.h>])
 
 AC_CHECK_DECLS(m4_normalize([
 	PTRACE_GET_SYSCALL_INFO,

--- a/src/main.c
+++ b/src/main.c
@@ -12,7 +12,6 @@ SPDX-License-Identifier: LGPL-2.1-or-later
 #include <stdlib.h>
 #include <sysexits.h>
 #include <unistd.h>
-#include "record.h"
 
 void run_and_record_fnames(char **av);
 
@@ -44,7 +43,6 @@ main(int argc, char **argv, char **envp)
     record_env(stdout, envp);
     record_cmdline(stdout, ++argv);
 
-    record_start("output.txt");
     run_and_record_fnames(argv);
 
     exit(EXIT_SUCCESS);

--- a/src/main.c
+++ b/src/main.c
@@ -12,13 +12,14 @@ SPDX-License-Identifier: LGPL-2.1-or-later
 #include <stdlib.h>
 #include <sysexits.h>
 #include <unistd.h>
+#include "record.h"
 
-void            run_and_record_fnames(char **av);
+void run_and_record_fnames(char **av);
 
 void
 record_cmdline(FILE *fout, char **ap)
 {
-    char          **p;
+    char **p;
 
     for (p = ap; *p != NULL; p++)
 	(void) fprintf(fout, "%s ", *p);
@@ -28,7 +29,7 @@ record_cmdline(FILE *fout, char **ap)
 void
 record_env(FILE *fout, char **ep)
 {
-    char          **p;
+    char **p;
 
     for (p = ep; *p != NULL; p++)
 	(void) fprintf(fout, "%s\n", *p);
@@ -43,6 +44,7 @@ main(int argc, char **argv, char **envp)
     record_env(stdout, envp);
     record_cmdline(stdout, ++argv);
 
+    record_start("output.txt");
     run_and_record_fnames(argv);
 
     exit(EXIT_SUCCESS);

--- a/src/tracer.c
+++ b/src/tracer.c
@@ -10,6 +10,7 @@ SPDX-License-Identifier: LGPL-2.1-or-later
 #include	<errno.h>
 #include	<error.h>
 #include	<stdlib.h>
+#include	<stdio.h>
 #include	<string.h>
 #include	<unistd.h>
 

--- a/src/tracer.c
+++ b/src/tracer.c
@@ -151,15 +151,40 @@ read_command_line(pid_t pid)
 
     close(fd);
 
+    size_t extra_bytes = 0;	  // extra bytes we will need for the escape
+				  // characters
     for (int i = 0; i < bytes; ++i) {
-	if (!cmd[i]) {
-	    cmd[i] = ' ';
+	extra_bytes += cmd[i] == '"' || cmd[i] == ' ';
+    }
+
+    char *command = (char *) malloc(bytes + extra_bytes);
+
+    int j = 0;
+
+    for (int i = 0; i < bytes; ++i) {
+	switch (cmd[i]) {
+	    case '"':
+		command[j] = '\\';
+		command[j + 1] = '"';
+		j += 2;
+		break;
+	    case ' ':
+		command[j] = '\\';
+		command[j + 1] = ' ';
+		j += 2;
+		break;
+	    case '\0':
+		command[j++] = ' ';
+		break;
+	    default:
+		command[j++] = cmd[i];
+		break;
 	}
     }
 
-    cmd[bytes] = 0;
+    command[j] = '\0';
 
-    return strdup(cmd);
+    return command;
 }
 
 static void

--- a/src/tracer.c
+++ b/src/tracer.c
@@ -152,12 +152,13 @@ read_command_line(pid_t pid)
     close(fd);
 
     size_t extra_bytes = 0;	  // extra bytes we will need for the escape
-				  // characters
+
+    // characters
     for (int i = 0; i < bytes; ++i) {
 	extra_bytes += cmd[i] == '"' || cmd[i] == ' ';
     }
 
-    char *command = (char *) malloc(bytes + extra_bytes);
+    char *command = (char *) malloc(bytes + extra_bytes + 1);
 
     int j = 0;
 

--- a/src/tracer.c
+++ b/src/tracer.c
@@ -203,15 +203,10 @@ handle_syscall(pid_t pid, const struct ptrace_syscall_info *entry,
 
 	    finfo = find(pid)->finfo + fd;
 
-<<<<<<< HEAD
-	    if(finfo->path != (char *) 0) {
-		finfo->hash = hash_file(finfo->path);
+	    if (finfo->path != (char *) 0) {
+		finfo->hash = get_file_hash(finfo->path);
 		record_fileuse(pid, finfo->path, finfo->purpose, finfo->hash);
 	    }
-=======
-	    finfo->hash = get_file_hash(finfo->path);
-	    record_fileuse(pid, finfo->path, finfo->purpose, finfo->hash);
->>>>>>> main
 	    break;
 	default:
 	    return;

--- a/src/tracer.c
+++ b/src/tracer.c
@@ -205,8 +205,10 @@ handle_syscall(pid_t pid, const struct ptrace_syscall_info *entry,
 
 	    finfo = find(pid)->finfo + fd;
 
-	    finfo->hash = hash_file(finfo->path);
-	    record_fileuse(pid, finfo->path, finfo->purpose, finfo->hash);
+	    if(finfo->path != (char *) 0) {
+		finfo->hash = hash_file(finfo->path);
+		record_fileuse(pid, finfo->path, finfo->purpose, finfo->hash);
+	    }
 	    break;
 	default:
 	    return;


### PR DESCRIPTION
Initial demo to trace process start and command. Closes #56 if and only if we go after the `cmdline` solution mentioned in that issue.