### PR TITLE
Configure fix

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -46,9 +46,12 @@ AC_CHECK_HEADERS([m4_normalize([
 
 dnl Checks for typedefs and structures
 AC_CHECK_TYPES(m4_normalize([
-	pid_t,
 	struct ptrace_syscall_info
 ]),,, [#include <linux/ptrace.h>])
+
+AC_CHECK_TYPES(m4_normalize([
+	pid_t
+]),,, [#include <sys/types.h>])
 
 AC_CHECK_TYPE([SHA_CTX],,, [#include <openssl/sha.h>])
 


### PR DESCRIPTION
Configure script was previously incorrectly looking for `pid_t` in `linux/ptrace.h` instead of `sys/types.h`. 