### PR TITLE
Openssl 3

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -27,12 +27,12 @@ AC_CONFIG_SRCDIR([src/main.c])
 
 dnl Checks for programs
 dnl Checks for libraries
-AC_CHECK_LIB(crypto, SHA1_Init)
+AC_CHECK_LIB(crypto, EVP_DigestInit_ex)
 
 dnl Checks for headers
 AC_CHECK_HEADERS([m4_normalize([
 	linux/ptrace.h
-	openssl/sha.h
+	openssl/evp.h
 	sys/mman.h
 	sys/ptrace.h
 	sys/signal.h
@@ -53,7 +53,10 @@ AC_CHECK_TYPES(m4_normalize([
 	pid_t
 ]),,, [#include <sys/types.h>])
 
-AC_CHECK_TYPE([SHA_CTX],,, [#include <openssl/sha.h>])
+AC_CHECK_TYPES(m4_normalize([
+	EVP_MD_CTX *,
+	EVP_MD *
+]),,, [#include <openssl/evp.h>])
 
 AC_CHECK_DECL([PATH_MAX],,, [#include <limits.h>])
 
@@ -89,7 +92,14 @@ AC_CHECK_DECLS(m4_normalize([
 AC_CHECK_DECL([MADV_SEQUENTIAL],,, [#include <sys/mman.h>])
 
 dnl Checks for functions
-AC_CHECK_FUNCS([SHA1_Init SHA1_Update SHA1_Final])
+AC_CHECK_FUNCS(m4_normalize([
+	EVP_get_digestbyname
+	EVP_MD_CTX_new
+	EVP_MD_CTX_free
+	EVP_DigestInit_ex
+	EVP_DigestUpdate
+	EVP_DigestFinal_ex
+]))
 AC_CHECK_FUNCS([fork ptrace waitpid wait])
 AC_CHECK_FUNCS([mmap madvise])
 

--- a/src/hash.c
+++ b/src/hash.c
@@ -22,8 +22,13 @@ SPDX-License-Identifier: LGPL-2.1-or-later
 #include <sys/types.h>		       // 
 #include <unistd.h>		       // optind, readlink(2)
 
-#include <openssl/sha.h>	       // SHA_CTX, SHA1_Init, SHA1_Update,
-				       // SHA1_Final
+#include <openssl/evp.h>	       // EVP_get_digestbyname(3)
+				       // EVP_MD_CTX_new(3)
+				       // EVP_MD_CTX_free(3)
+				       // EVP_DigestInit_ex(3)
+				       // EVP_DigestUpdate(3)
+				       // EVP_DigestFinal_ex(3)
+
 #define SHA1_OUTPUT_LEN 20
 #define SHA1_HEXBUF_LEN (2 * SHA1_OUTPUT_LEN + 1)
 
@@ -77,7 +82,6 @@ hash_file_contents(char *name, size_t sz)
 
     presize = sprintf(pre, "blob %lu%c", sz, 0);
 
-    SHA_CTX ctx;
     unsigned char *hash;
 
     hash = malloc(SHA1_OUTPUT_LEN);
@@ -86,10 +90,20 @@ hash_file_contents(char *name, size_t sz)
 	return NULL;
     }
 
-    SHA1_Init(&ctx);
-    SHA1_Update(&ctx, pre, presize);
-    SHA1_Update(&ctx, buf, sz);
-    SHA1_Final(hash, &ctx);
+    EVP_MD_CTX *mdctx;
+    const EVP_MD *md;
+
+    md = EVP_get_digestbyname("SHA1");
+    if (md == NULL) {
+	error(0, errno, "digestbyname");
+    }
+
+    mdctx = EVP_MD_CTX_new();
+    EVP_DigestInit_ex(mdctx, md, NULL);
+    EVP_DigestUpdate(mdctx, pre, presize);
+    EVP_DigestUpdate(mdctx, buf, sz);
+    EVP_DigestFinal_ex(mdctx, hash, NULL);
+    EVP_MD_CTX_free(mdctx);
 
     close(fd);
 


### PR DESCRIPTION
Closes #32. Note that these functions are available for usage prior to OpenSSL3 too. They just weren't deprecated. Thus we don't need to make configure-type checks to see what to use and we can default to these anyways.