### PR TITLE
[BUGFIX] Now properly uses "pi" instead of global variable "pinfo"

### DIFF
--- a/src/tracer.c
+++ b/src/tracer.c
@@ -72,22 +72,22 @@ next_pinfo(void)
 FILE_INFO *
 finfo_at(PROCESS_INFO *pi, int index)
 {
-    if (index >= pinfo->finfo_size) {
-	int prev_size = pinfo->finfo_size;
+    if (index >= pi->finfo_size) {
+	int prev_size = pi->finfo_size;
 
 	do {
-	    pinfo->finfo_size *= 2;
-	} while (index >= pinfo->finfo_size);
+	    pi->finfo_size *= 2;
+	} while (index >= pi->finfo_size);
 
 	pi->finfo = reallocarray(pi->finfo, pi->finfo_size, sizeof (FILE_INFO));
 	if (pi->finfo == NULL) {
 	    error(EXIT_FAILURE, errno,
 		  "reallocating file info array in process %d", pi->pid);
 	}
-	memset(pi->finfo + prev_size, 0, pinfo->finfo_size - prev_size);
+	memset(pi->finfo + prev_size, 0, pi->finfo_size - prev_size);
     }
 
-    return pinfo->finfo + index;
+    return pi->finfo + index;
 }
 
 char *


### PR DESCRIPTION
Yet another silly bug, global variables deserve the hate. Closes #87 