### PR TITLE
[CORE] implemented rename tracing, record format demo, code structure changed

### DIFF
--- a/src/record.c
+++ b/src/record.c
@@ -167,7 +167,12 @@ record_fileuse(char *poutname, char *foutname, char *path, int purpose,
 void
 record_rename(char *poutname, char *from, char *to)
 {
-    // TODO define format
-    // This is just a demo for testing 
-    record_triple(from, "rename", to, true);
+    static int rename = 0;
+    char unnamed_mod[16];
+
+    sprintf(unnamed_mod, "_:rename%d", rename++);
+
+    record_triple(poutname, "b:rename", unnamed_mod, false);
+    record_triple(unnamed_mod, "b:rename-from", from, true);
+    record_triple(unnamed_mod, "b:rename-to", to, true);
 }

--- a/src/record.c
+++ b/src/record.c
@@ -163,3 +163,11 @@ record_fileuse(char *poutname, char *foutname, char *path, int purpose,
 	record_triple(poutname, "b:writes", foutname, false);
     }
 }
+
+void
+record_rename(char *poutname, char *from, char *to)
+{
+    // TODO define format
+    // This is just a demo for testing 
+    record_triple(from, "rename", to, true);
+}

--- a/src/record.h
+++ b/src/record.h
@@ -7,3 +7,4 @@ void record_process_end(char *poutname);
 void record_process_env(char *poutname, char **envp);
 void record_fileuse(char *poutname, char *foutname, char *path, int purpose,
 		    char *hash);
+void record_rename(char *poutname, char *from, char *to);

--- a/src/types.h
+++ b/src/types.h
@@ -45,4 +45,5 @@ typedef struct {
     FILE_INFO *finfo;
     int finfo_size;
     struct ptrace_syscall_info state;
+    void *entry_info;
 } PROCESS_INFO;


### PR DESCRIPTION
Huge changes in this pull request.

A scenario which has been troubling me for quite some time now, handlers who run during `syscall_entry` instead of `syscall_stop`.

To implement the tracing of `rename(2)` calls i once again needed that feature. This time instead of hacking my way around it i decided to tackle it with a demo solution.

That is:

## Create a new function `handle_syscall_entry(3)` that's called upon `PTRACE_SYSCALL_INFO_ENTRY`
Said function has the same structure the original `handle_syscall(3)` had and is meant to run computations that we can't run after the system call has returned(that is, on `PTRACE_SYSCALL_INFO_EXIT`). A new entry has been introduced in `PROCESS_INFO` to hold the result of the former function's computations, namely `PROCESS_INFO::entry_info`.

## Refactoring
Original `handle_syscall(3)` has been renamed to `handle_syscall_exit(3)`.

## Record rename
A demo for `record_rename` has been written purely for testing until an actual format is decided.