### PR TITLE
[BUGFIX] Out of bounds access Segfault fix

### DIFF
--- a/src/tracer.c
+++ b/src/tracer.c
@@ -55,7 +55,7 @@ init_pinfo(void)
 PROCESS_INFO *
 next_pinfo(void)
 {
-    if (numpinfo >= pinfo_size) {
+    if (numpinfo == pinfo_size - 1) {
 	pinfo_size *= 2;
 	pinfo = reallocarray(pinfo, pinfo_size, sizeof (PROCESS_INFO));
 	if (pinfo == NULL)


### PR DESCRIPTION
Found a bug while trying to compile the [xbps package manager](https://github.com/void-linux/xbps). Turns out `next_pinfo` was buggy.