### PR TITLE
[BUGFIX] Now properly finds the realpath of absolute paths

### DIFF
--- a/src/tracer.c
+++ b/src/tracer.c
@@ -119,7 +119,7 @@ absolutepath(pid_t pid, int dirfd, char *addr)
     char symbpath[PATH_MAX];
 
     if (*addr == '/') {
-	return strdup(addr);
+	return realpath(addr, NULL);
     }
     if (dirfd == AT_FDCWD) {
 	sprintf(symbpath, "/proc/%d/cwd/%s", pid, addr);


### PR DESCRIPTION
Previously we would just `strdup(3)` absolute paths in `absolutepath(3)`, this proved to be incorrect since "unreal" paths(such as `/usr/bin/../lib`) would falsely be duplicated and marked as absolute paths. Now properly uses `realpath(3)` in that scenario as well.