### PR TITLE
[IMPROVEMENT] Maintenance refactoring

### DIFF
--- a/.indent.pro
+++ b/.indent.pro
@@ -87,6 +87,5 @@
 /* project-specific types */
 -TFILE_INFO
 -TPROCESS_INFO
--TFINFOS
--TPINFOS
+-TCONTEXT
 

--- a/.indent.pro
+++ b/.indent.pro
@@ -87,4 +87,6 @@
 /* project-specific types */
 -TFILE_INFO
 -TPROCESS_INFO
+-TFINFOS
+-TPINFOS
 

--- a/Makefile.am
+++ b/Makefile.am
@@ -11,5 +11,6 @@ build_recorder_SOURCES = \
     src/tracer.c \
     src/hash.c \
     src/record.c \
+    src/types.c \
     src/main.c
 

--- a/src/tracer.c
+++ b/src/tracer.c
@@ -391,7 +391,7 @@ handle_syscall_exit(CONTEXT *ctx, PROCESS_INFO *pi,
 }
 
 static void
-tracer_main(PROCESS_INFO *pi, char *path, char **envp, CONTEXT *ctx)
+tracer_main(CONTEXT *ctx, PROCESS_INFO *pi, char *path, char **envp)
 {
     waitpid(pi->pid, NULL, 0);
 

--- a/src/types.c
+++ b/src/types.c
@@ -1,0 +1,147 @@
+
+/*
+Copyright (C) 2022 Valasiadis Fotios
+Copyright (C) 2022 Alexios Zavras
+SPDX-License-Identifier: LGPL-2.1-or-later
+*/
+
+#include	<stdio.h>	       /* sprintf(3) */
+#include	<stdlib.h>	       /* calloc(3), reallocarray(3) */
+#include	<string.h>	       /* strcmp(3) */
+#include	<error.h>	       /* error(3) */
+#include	<errno.h>	       /* errno */
+
+#include	"types.h"
+
+/* PROCESS_INFO methods */
+
+void
+pinfo_new(PROCESS_INFO *self, int numpinfo, pid_t pid, char ignore_one_sigstop)
+{
+    sprintf(self->outname, ":p%d", numpinfo);
+    self->pid = pid;
+    self->finfo_size = DEFAULT_FINFO_SIZE;
+    self->finfo = calloc(self->finfo_size, sizeof (FILE_INFO));
+    self->ignore_one_sigstop = ignore_one_sigstop;
+}
+
+int *
+pinfo_finfo_at(PROCESS_INFO *self, int index)
+{
+    if (index >= self->finfo_size) {
+	int prev_size = self->finfo_size;
+
+	do {
+	    self->finfo_size *= 2;
+	} while (index >= self->finfo_size);
+
+	self->finfo =
+		reallocarray(self->finfo, self->finfo_size, sizeof (FILE_INFO));
+	if (self->finfo == NULL) {
+	    error(EXIT_FAILURE, errno,
+		  "reallocating file info array in process %d", self->pid);
+	}
+
+	for (int i = prev_size; i < self->finfo_size; ++i) {
+	    self->finfo[i] = -1;
+	}
+    }
+
+    return self->finfo + index;
+}
+
+/* FILE_INFO methods */
+
+void
+finfo_new(FILE_INFO *self, int numfinfo, char *path, char *abspath, char *hash)
+{
+    sprintf(self->outname, ":f%d", numfinfo);
+    self->was_hash_printed = 0;
+    self->path = path;
+    self->abspath = abspath;
+    self->hash = hash;
+}
+
+/* FINFOS methods */
+
+void
+finfos_init(FINFOS *self)
+{
+    self->finfo_size = DEFAULT_FINFO_SIZE;
+    self->finfo = calloc(self->finfo_size, sizeof (FILE_INFO));
+    self->numfinfo = -1;
+}
+
+FILE_INFO *
+finfos_next_finfo(FINFOS *self)
+{
+    if (self->numfinfo == self->finfo_size - 1) {
+	self->finfo_size *= 2;
+	self->finfo =
+		reallocarray(self->finfo, self->finfo_size, sizeof (FILE_INFO));
+	if (self->finfo == NULL)
+	    error(EXIT_FAILURE, errno, "reallocating file info array");
+    }
+
+    return self->finfo + (++self->numfinfo);
+}
+
+FILE_INFO *
+finfos_find_finfo(FINFOS *self, char *abspath, char *hash)
+{
+    int i = self->numfinfo;
+
+    while (i >= 0 && !(!strcmp(abspath, self->finfo[i].abspath)
+		       && (!(self->finfo[i].was_hash_printed)
+			   || (hash == NULL && self->finfo[i].hash == NULL)
+			   || !strcmp(hash, self->finfo[i].hash)))) {
+	--i;
+    }
+
+    if (i < 0) {
+	return NULL;
+    }
+
+    return self->finfo + i;
+}
+
+/* PINFOS methods */
+
+void
+pinfos_init(PINFOS *self)
+{
+    self->pinfo_size = DEFAULT_PINFO_SIZE;
+    self->pinfo = calloc(self->pinfo_size, sizeof (PROCESS_INFO));
+    self->numpinfo = -1;
+}
+
+PROCESS_INFO *
+pinfos_next_pinfo(PINFOS *self)
+{
+    if (self->numpinfo == self->pinfo_size - 1) {
+	self->pinfo_size *= 2;
+	self->pinfo =
+		reallocarray(self->pinfo, self->pinfo_size,
+			     sizeof (PROCESS_INFO));
+	if (self->pinfo == NULL)
+	    error(EXIT_FAILURE, errno, "reallocating process info array");
+    }
+
+    return self->pinfo + (++self->numpinfo);
+}
+
+PROCESS_INFO *
+pinfos_find_pinfo(PINFOS *self, pid_t pid)
+{
+    int i = self->numpinfo;
+
+    while (i >= 0 && self->pinfo[i].pid != pid) {
+	--i;
+    }
+
+    if (i < 0) {
+	return NULL;
+    }
+
+    return self->pinfo + i;
+}

--- a/src/types.c
+++ b/src/types.c
@@ -91,7 +91,7 @@ context_next_finfo(CONTEXT *self)
 }
 
 FILE_INFO *
-context_find_finfo(CONTEXT *self, char *abspath, char *hash)
+context_find_finfo(const CONTEXT *self, char *abspath, char *hash)
 {
     int i = self->numfinfo;
 
@@ -125,7 +125,7 @@ context_next_pinfo(CONTEXT *self)
 }
 
 PROCESS_INFO *
-context_find_pinfo(CONTEXT *self, pid_t pid)
+context_find_pinfo(const CONTEXT *self, pid_t pid)
 {
     int i = self->numpinfo;
 

--- a/src/types.c
+++ b/src/types.c
@@ -62,18 +62,22 @@ finfo_new(FILE_INFO *self, int numfinfo, char *path, char *abspath, char *hash)
     self->hash = hash;
 }
 
-/* FINFOS methods */
+/* CONTEXT methods */
 
 void
-finfos_init(FINFOS *self)
+context_init(CONTEXT *self)
 {
     self->finfo_size = DEFAULT_FINFO_SIZE;
     self->finfo = calloc(self->finfo_size, sizeof (FILE_INFO));
     self->numfinfo = -1;
+
+    self->pinfo_size = DEFAULT_PINFO_SIZE;
+    self->pinfo = calloc(self->pinfo_size, sizeof (PROCESS_INFO));
+    self->numpinfo = -1;
 }
 
 FILE_INFO *
-finfos_next_finfo(FINFOS *self)
+context_next_finfo(CONTEXT *self)
 {
     if (self->numfinfo == self->finfo_size - 1) {
 	self->finfo_size *= 2;
@@ -87,7 +91,7 @@ finfos_next_finfo(FINFOS *self)
 }
 
 FILE_INFO *
-finfos_find_finfo(FINFOS *self, char *abspath, char *hash)
+context_find_finfo(CONTEXT *self, char *abspath, char *hash)
 {
     int i = self->numfinfo;
 
@@ -105,18 +109,8 @@ finfos_find_finfo(FINFOS *self, char *abspath, char *hash)
     return self->finfo + i;
 }
 
-/* PINFOS methods */
-
-void
-pinfos_init(PINFOS *self)
-{
-    self->pinfo_size = DEFAULT_PINFO_SIZE;
-    self->pinfo = calloc(self->pinfo_size, sizeof (PROCESS_INFO));
-    self->numpinfo = -1;
-}
-
 PROCESS_INFO *
-pinfos_next_pinfo(PINFOS *self)
+context_next_pinfo(CONTEXT *self)
 {
     if (self->numpinfo == self->pinfo_size - 1) {
 	self->pinfo_size *= 2;
@@ -131,7 +125,7 @@ pinfos_next_pinfo(PINFOS *self)
 }
 
 PROCESS_INFO *
-pinfos_find_pinfo(PINFOS *self, pid_t pid)
+context_find_pinfo(CONTEXT *self, pid_t pid)
 {
     int i = self->numpinfo;
 

--- a/src/types.h
+++ b/src/types.h
@@ -54,13 +54,11 @@ typedef struct {
     FILE_INFO *finfo;
     int numfinfo;
     int finfo_size;
-} FINFOS;
 
-typedef struct {
     PROCESS_INFO *pinfo;
     int numpinfo;
     int pinfo_size;
-} PINFOS;
+} CONTEXT;
 
 /* PROCESS_INFO methods */
 void pinfo_new(PROCESS_INFO *self, int numpinfo, pid_t pid,
@@ -71,16 +69,12 @@ int *pinfo_finfo_at(PROCESS_INFO *self, int index);
 void finfo_new(FILE_INFO *self, int numfinfo, char *path, char *abspath,
 	       char *hash);
 
-/* FINFOS methods */
+/* CONTEXT methods */
 #define DEFAULT_FINFO_SIZE	32
-
-void finfos_init(FINFOS *self);
-FILE_INFO *finfos_next_finfo(FINFOS *self);
-FILE_INFO *finfos_find_finfo(FINFOS *self, char *abspath, char *hash);
-
-/* PINFOS methods */
 #define DEFAULT_PINFO_SIZE	32
 
-void pinfos_init(PINFOS *self);
-PROCESS_INFO *pinfos_next_pinfo(PINFOS *self);
-PROCESS_INFO *pinfos_find_pinfo(PINFOS *self, pid_t pid);
+void context_init(CONTEXT *self);
+FILE_INFO *context_next_finfo(CONTEXT *self);
+FILE_INFO *context_find_finfo(CONTEXT *self, char *abspath, char *hash);
+PROCESS_INFO *context_next_pinfo(CONTEXT *self);
+PROCESS_INFO *context_find_pinfo(CONTEXT *self, pid_t pid);

--- a/src/types.h
+++ b/src/types.h
@@ -75,6 +75,6 @@ void finfo_new(FILE_INFO *self, int numfinfo, char *path, char *abspath,
 
 void context_init(CONTEXT *self);
 FILE_INFO *context_next_finfo(CONTEXT *self);
-FILE_INFO *context_find_finfo(CONTEXT *self, char *abspath, char *hash);
+FILE_INFO *context_find_finfo(const CONTEXT *self, char *abspath, char *hash);
 PROCESS_INFO *context_next_pinfo(CONTEXT *self);
-PROCESS_INFO *context_find_pinfo(CONTEXT *self, pid_t pid);
+PROCESS_INFO *context_find_pinfo(const CONTEXT *self, pid_t pid);

--- a/src/types.h
+++ b/src/types.h
@@ -49,3 +49,38 @@ typedef struct {
     void *entry_info;
     char ignore_one_sigstop;
 } PROCESS_INFO;
+
+typedef struct {
+    FILE_INFO *finfo;
+    int numfinfo;
+    int finfo_size;
+} FINFOS;
+
+typedef struct {
+    PROCESS_INFO *pinfo;
+    int numpinfo;
+    int pinfo_size;
+} PINFOS;
+
+/* PROCESS_INFO methods */
+void pinfo_new(PROCESS_INFO *self, int numpinfo, pid_t pid,
+	       char ignore_one_sigstop);
+int *pinfo_finfo_at(PROCESS_INFO *self, int index);
+
+/* FILE_INFO methods */
+void finfo_new(FILE_INFO *self, int numfinfo, char *path, char *abspath,
+	       char *hash);
+
+/* FINFOS methods */
+#define DEFAULT_FINFO_SIZE	32
+
+void finfos_init(FINFOS *self);
+FILE_INFO *finfos_next_finfo(FINFOS *self);
+FILE_INFO *finfos_find_finfo(FINFOS *self, char *abspath, char *hash);
+
+/* PINFOS methods */
+#define DEFAULT_PINFO_SIZE	32
+
+void pinfos_init(PINFOS *self);
+PROCESS_INFO *pinfos_next_pinfo(PINFOS *self);
+PROCESS_INFO *pinfos_find_pinfo(PINFOS *self, pid_t pid);


### PR DESCRIPTION
Wraps previously global state to a single newly-defined `struct` named `CONTEXT` in `src/types.h` and moves all functions that previously modified `CONTEXT` to a new module named `src/types.c`. The functions are now all prefixed with the "class"'s name in an oop style. This is to separate the context from the tracing functionality and encapsulate the context so we reason about its data accesses for future optimizations.

Also some minor changes such as variable renames.

This pull request aims to organize our state so i can perform modifications to optimize `build_recorder` in the future.