### PR TITLE
[IMPROVEMENT] Data oriented design and optimizations

### DIFF
--- a/src/tracer.c
+++ b/src/tracer.c
@@ -620,7 +620,7 @@ tracer_main(pid_t pid, PROCESS_INFO *pi, char *path, char **envp)
 
 	    record_process_end(process_state->outname);
 
-	    free(process_state->cmdline);
+	    free(process_state->cmd_line);
 	    free(process_state->finfo);
 
 	    int i = process_state - pinfo;

--- a/src/tracer.c
+++ b/src/tracer.c
@@ -56,6 +56,7 @@ init(void)
 {
     pinfo_size = DEFAULT_PINFO_SIZE;
     pinfo = calloc(pinfo_size, sizeof (PROCESS_INFO));
+    pids = malloc(pinfo_size * sizeof (int));
     numpinfo = -1;
 
     finfo_size = DEFAULT_FINFO_SIZE;
@@ -69,6 +70,7 @@ next_pinfo(pid_t pid)
     if (numpinfo == pinfo_size - 1) {
 	pinfo_size *= 2;
 	pinfo = reallocarray(pinfo, pinfo_size, sizeof (PROCESS_INFO));
+	pids = reallocarray(pids, pinfo_size, sizeof (int));
 	if (pinfo == NULL)
 	    error(EXIT_FAILURE, errno, "reallocating process info array");
     }

--- a/src/tracer.c
+++ b/src/tracer.c
@@ -620,6 +620,9 @@ tracer_main(pid_t pid, PROCESS_INFO *pi, char *path, char **envp)
 
 	    record_process_end(process_state->outname);
 
+	    free(process_state->cmdline);
+	    free(process_state->finfo);
+
 	    int i = process_state - pinfo;
 
 	    for (int i = process_state - pinfo; i < numpinfo; ++i) {

--- a/src/tracer.c
+++ b/src/tracer.c
@@ -146,9 +146,9 @@ find_finfo(char *abspath, char *hash)
 	    continue;
 	}
 
-	if (!strcmp(abspath, finfo[i].abspath)
-	    && ((hash == NULL && finfo[i].hash == NULL)
-		|| !strcmp(hash, finfo[i].hash))) {
+	if (((hash == NULL && finfo[i].hash == NULL)
+	     || !strcmp(hash, finfo[i].hash))
+	    && !strcmp(abspath, finfo[i].abspath)) {
 	    break;
 	}
 

--- a/src/tracer.c
+++ b/src/tracer.c
@@ -98,7 +98,9 @@ next_finfo(void)
 void
 pinfo_new(PROCESS_INFO *self, char ignore_one_sigstop)
 {
-    sprintf(self->outname, ":p%d", numpinfo);
+    static int pcount = 0;
+
+    sprintf(self->outname, ":p%d", pcount++);
     self->finfo_size = DEFAULT_FINFO_SIZE;
     self->finfo = calloc(self->finfo_size, sizeof (FILE_INFO));
     self->ignore_one_sigstop = ignore_one_sigstop;
@@ -139,7 +141,7 @@ find_finfo(char *abspath, char *hash)
 
     while (i >= 0) {
 	if (finfo[i].was_hash_printed == 0) {	// We don't want an
-						// incomplete entry.
+	    // incomplete entry.
 	    --i;
 	    continue;
 	}

--- a/src/types.h
+++ b/src/types.h
@@ -32,8 +32,7 @@ typedef struct {
 } FILE_INFO;
 
 /*
- * For each (sub-)process we keep its pid,
- * the command line (including all the arguments)
+ * For each (sub-)process we keep the command line (including all the arguments),
  * the number of files recorded,
  * the actual information on the files,
  * and, while it's running, its current syscall
@@ -41,7 +40,6 @@ typedef struct {
  */
 typedef struct {
     char outname[16];
-    pid_t pid;
     char *cmd_line;
     int *finfo;
     int finfo_size;


### PR DESCRIPTION
`pinfo` array has been re-organized to maximize cache-hits when searching using `find_pinfo(3)`. Processes that end are now removed from the array as discussed in #131 .