### PR TITLE
[IMPROVEMENT] Hashmap implementation! Bigger builds are now faster!

### DIFF
--- a/.indent.pro
+++ b/.indent.pro
@@ -86,6 +86,10 @@
 
 /* project-specific types */
 -TFILE_INFO
+-TFILE_WRITE
 -TPROCESS_INFO
--Thashtable
+-Thashmap
+-Tkey_type
+-Tvalue_type
+
 

--- a/.indent.pro
+++ b/.indent.pro
@@ -87,4 +87,5 @@
 /* project-specific types */
 -TFILE_INFO
 -TPROCESS_INFO
+-Thashtable
 

--- a/Makefile.am
+++ b/Makefile.am
@@ -11,5 +11,6 @@ build_recorder_SOURCES = \
     src/tracer.c \
     src/hash.c \
     src/record.c \
+    src/hashmap.c \
     src/main.c
 

--- a/src/hash.c
+++ b/src/hash.c
@@ -24,8 +24,6 @@ SPDX-License-Identifier: LGPL-2.1-or-later
 
 #include <openssl/sha.h>	       // SHA_CTX, SHA1_Init, SHA1_Update,
 				       // SHA1_Final
-#define SHA1_OUTPUT_LEN 20
-#define SHA1_HEXBUF_LEN (2 * SHA1_OUTPUT_LEN + 1)
 
 #define	ZERO_FILE_HASH	"e69de29bb2d1d6434b8b29ae775ad8c2e48c5391"
 

--- a/src/hash.h
+++ b/src/hash.h
@@ -1,3 +1,7 @@
 
 /* hash.c */
+
+#define SHA1_OUTPUT_LEN 20
+#define SHA1_HEXBUF_LEN (2 * SHA1_OUTPUT_LEN + 1)
+
 char *get_file_hash(char *fname);

--- a/src/hashmap.c
+++ b/src/hashmap.c
@@ -26,10 +26,10 @@ hash_str(char *str)
 }
 
 static void
- hashmap_reallocate(hashmap * self);
+ hashmap_reallocate(hashmap *self);
 
 static void
-hashmap_new_impl(hashmap * self, int capacity)
+hashmap_new_impl(hashmap *self, int capacity)
 {
     self->keys = calloc(capacity, sizeof (key_type));
     self->values = calloc(capacity, sizeof (value_type));
@@ -42,13 +42,13 @@ hashmap_new_impl(hashmap * self, int capacity)
 }
 
 void
-hashmap_new(hashmap * self)
+hashmap_new(hashmap *self)
 {
     hashmap_new_impl(self, DEFAULT_CAPACITY);
 }
 
 value_type *
-hashmap_insert(hashmap * self, key_type key)
+hashmap_insert(hashmap *self, key_type key)
 {
     if (self->size == self->capacity) {
 	hashmap_reallocate(self);
@@ -68,23 +68,23 @@ hashmap_insert(hashmap * self, key_type key)
 	}
     }
 
-    if (!self->keys[pos])
+    if (!self->keys[pos]) {
 	self->keys[pos] = key;
-
-    ++self->size;
+	++self->size;
+    }
 
     return self->values + pos;
 }
 
 static void
-hashmap_free(hashmap * self)
+hashmap_free(hashmap *self)
 {
     free(self->keys);
     free(self->values);
 }
 
 static void
-hashmap_reallocate(hashmap * self)
+hashmap_reallocate(hashmap *self)
 {
     hashmap hm;
 

--- a/src/hashmap.c
+++ b/src/hashmap.c
@@ -1,0 +1,102 @@
+
+/*
+Copyright (C) 2022 Valasiadis Fotios
+SPDX-License-Identifier: LGPL-2.1-or-later
+*/
+
+#include	<stdlib.h>
+#include	<string.h>
+#include	<error.h>
+#include	<errno.h>
+#include	"hashmap.h"
+
+#define DEFAULT_CAPACITY 32
+
+int
+hash_str(char *str)
+{
+    int hash = 7;
+
+    while (*str) {
+	hash = hash * 31 + *str;
+	++str;
+    }
+
+    return hash;
+}
+
+static void
+ hashmap_reallocate(hashmap * self);
+
+static void
+hashmap_new_impl(hashmap * self, int capacity)
+{
+    self->keys = calloc(capacity, sizeof (key_type));
+    self->values = calloc(capacity, sizeof (value_type));
+
+    if (!self->keys || !self->values)
+	error(EXIT_FAILURE, errno, "on hashmap_new");
+
+    self->capacity = capacity;
+    self->size = 0;
+}
+
+void
+hashmap_new(hashmap * self)
+{
+    hashmap_new_impl(self, DEFAULT_CAPACITY);
+}
+
+value_type *
+hashmap_insert(hashmap * self, key_type key)
+{
+    if (self->size == self->capacity) {
+	hashmap_reallocate(self);
+    }
+
+    int pos = hash_str(key) & (self->capacity - 1);
+
+    while (pos != self->capacity && self->keys[pos]
+	   && strcmp(self->keys[pos], key)) {
+	++pos;
+    }
+
+    if (pos == self->capacity) {
+	pos = 0;
+	while (self->keys[pos] && strcmp(self->keys[pos], key)) {
+	    ++pos;
+	}
+    }
+
+    if (!self->keys[pos])
+	self->keys[pos] = key;
+
+    ++self->size;
+
+    return self->values + pos;
+}
+
+static void
+hashmap_free(hashmap * self)
+{
+    free(self->keys);
+    free(self->values);
+}
+
+static void
+hashmap_reallocate(hashmap * self)
+{
+    hashmap hm;
+
+    hashmap_new_impl(&hm, self->capacity * 2);
+
+    for (int i = 0; i < self->capacity; ++i) {
+	if (!self->keys[i])
+	    continue;
+
+	*hashmap_insert(&hm, self->keys[i]) = self->values[i];
+    }
+
+    hashmap_free(self);
+    *self = hm;
+}

--- a/src/hashmap.h
+++ b/src/hashmap.h
@@ -18,6 +18,12 @@ typedef struct {
     int capacity;
 } hashmap;
 
-void hashmap_new(hashmap * self);
+typedef struct {
+    key_type *key;
+    value_type *value;
+    char was_inserted;
+} hashmap_insertion;
 
-value_type *hashmap_insert(hashmap * self, key_type key);
+void hashmap_new(hashmap *self);
+
+value_type *hashmap_insert(hashmap *self, key_type key);

--- a/src/hashmap.h
+++ b/src/hashmap.h
@@ -18,12 +18,6 @@ typedef struct {
     int capacity;
 } hashmap;
 
-typedef struct {
-    key_type *key;
-    value_type *value;
-    char was_inserted;
-} hashmap_insertion;
-
 void hashmap_new(hashmap *self);
 
 value_type *hashmap_insert(hashmap *self, key_type key);

--- a/src/hashmap.h
+++ b/src/hashmap.h
@@ -1,0 +1,23 @@
+
+/*
+Copyright (C) 2022 Valasiadis Fotios
+SPDX-License-Identifier: LGPL-2.1-or-later
+*/
+
+#include "types.h"
+
+/* Simple hashmap with open addressing linear probing. */
+
+typedef char *key_type;
+typedef FILE_INFO value_type;
+
+typedef struct {
+    key_type *keys;
+    value_type *values;
+    int size;
+    int capacity;
+} hashmap;
+
+void hashmap_new(hashmap * self);
+
+value_type *hashmap_insert(hashmap * self, key_type key);

--- a/src/tracer.c
+++ b/src/tracer.c
@@ -83,19 +83,6 @@ next_pinfo(pid_t pid)
     return pinfo + (++numpinfo);
 }
 
-FILE_INFO *
-next_finfo(void)
-{
-    if (numfinfo == finfo_size - 1) {
-	finfo_size *= 2;
-	finfo = reallocarray(finfo, finfo_size, sizeof (FILE_INFO));
-	if (finfo == NULL)
-	    error(EXIT_FAILURE, errno, "reallocating file info array");
-    }
-
-    return finfo + (++numfinfo);
-}
-
 void
 pinfo_new(PROCESS_INFO *self, char ignore_one_sigstop)
 {
@@ -110,13 +97,10 @@ pinfo_new(PROCESS_INFO *self, char ignore_one_sigstop)
 }
 
 void
-finfo_new(FILE_INFO *self, char *path, char *abspath, char *hash)
+finfo_new(FILE_INFO *self)
 {
     static int fcount = 0;
 
-    self->path = path;
-    self->abspath = abspath;
-    self->hash = hash;
     sprintf(self->outname, ":f%d", fcount++);
 }
 
@@ -136,29 +120,7 @@ find_pinfo(pid_t pid)
     return pinfo + i;
 }
 
-FILE_INFO *
-find_finfo(char *abspath, char *hash)
-{
-    int i = numfinfo;
-
-    while (i >= 0) {
-	if (!strcmp(abspath, finfo[i].abspath)
-	    && ((hash == NULL && finfo[i].hash == NULL)
-		|| !strcmp(hash, finfo[i].hash))) {
-	    break;
-	}
-
-	--i;
-    }
-
-    if (i < 0) {
-	return NULL;
-    }
-
-    return finfo + i;
-}
-
-FILE_INFO *
+FILE_WRITE *
 pinfo_find_finfo(PROCESS_INFO *self, int fd)
 {
     int i = self->numfinfo;
@@ -174,15 +136,15 @@ pinfo_find_finfo(PROCESS_INFO *self, int fd)
     return self->finfo + i;
 }
 
-FILE_INFO *
+FILE_WRITE *
 pinfo_next_finfo(PROCESS_INFO *self, int fd)
 {
     if (self->numfinfo == self->finfo_size - 1) {
 	self->finfo_size *= 2;
 	self->finfo =
-		reallocarray(self->finfo, self->finfo_size, sizeof (FILE_INFO));
-	self->fds =
-		reallocarray(self->fds, self->finfo_size, sizeof (FILE_INFO));
+		reallocarray(self->finfo, self->finfo_size,
+			     sizeof (FILE_WRITE));
+	self->fds = reallocarray(self->fds, self->finfo_size, sizeof (int));
 	if (self->finfo == NULL)
 	    error(EXIT_FAILURE, errno, "reallocating file info array");
     }
@@ -262,6 +224,19 @@ find_in_path(char *path)
     return ret;
 }
 
+static char *
+craft_key(const char *abspath, const char *hash)
+{
+    if (!hash)			       /* If it's a folder */
+	return strdup(abspath);
+
+    char *key = (char *) malloc(strlen(abspath) + SHA1_HEXBUF_LEN);
+
+    strcpy(key, hash);
+    strcat(key, abspath);
+    return key;
+}
+
 static void
 handle_open(pid_t pid, PROCESS_INFO *pi, int fd, int dirfd, void *path,
 	    int purpose)
@@ -276,24 +251,32 @@ handle_open(pid_t pid, PROCESS_INFO *pi, int fd, int dirfd, void *path,
 
     if ((purpose & O_ACCMODE) == O_RDONLY) {
 	char *hash = get_file_hash(abspath);
+	char *key = craft_key(abspath, hash);
 
-	f = hashmap_insert(&finfo, hash);
+	f = hashmap_insert(&finfo, key);
 	if (!*(char *) f) {
-	    finfo_new(f, path, abspath, hash);
+	    finfo_new(f);
 	    record_file(f->outname, path, abspath);
 	    record_hash(f->outname, hash);
 	} else {
-	    free(path);
-	    free(abspath);
-	    free(hash);
+	    free(key);
 	}
+
+	free(abspath);
+	free(hash);
     } else {
-	f = pinfo_next_finfo(pi, fd);
-	finfo_new(f, path, abspath, NULL);
+	FILE_WRITE *fw = pinfo_next_finfo(pi, fd);
+
+	f = &(fw->f);
+	fw->abspath = abspath;
+
+	finfo_new(f);
 	record_file(f->outname, path, abspath);
     }
 
     record_fileuse(pi->outname, f->outname, purpose);
+
+    free(path);
 }
 
 static void
@@ -316,22 +299,22 @@ handle_execve(pid_t pid, PROCESS_INFO *pi, int dirfd, char *path)
     }
 
     char *hash = get_file_hash(abspath);
+    char *key = craft_key(abspath, hash);
 
-    FILE_INFO *f;
+    FILE_INFO *f = hashmap_insert(&finfo, key);
 
-    if (!(f = find_finfo(abspath, hash))) {
-	f = next_finfo();
-
-	finfo_new(f, path, abspath, hash);
+    if (!*(char *) f) {
+	finfo_new(f);
 	record_file(f->outname, path, abspath);
-	record_hash(f->outname, f->hash);
+	record_hash(f->outname, hash);
     } else {
-	free(abspath);
-	free(hash);
-	free(path);
+	free(key);
     }
 
     record_exec(pi->outname, f->outname);
+
+    free(abspath);
+    free(hash);
 }
 
 static void
@@ -339,39 +322,53 @@ handle_rename_entry(pid_t pid, PROCESS_INFO *pi, int olddirfd, char *oldpath)
 {
     char *abspath = absolutepath(pid, olddirfd, oldpath);
     char *hash = get_file_hash(abspath);
+    char *key = craft_key(abspath, hash);
+    char *dup;			  /* Duplicate the key so we can pass it to
+				     rename_exit */
 
-    FILE_INFO *f = find_finfo(abspath, hash);
+    FILE_INFO *f = hashmap_insert(&finfo, key);
 
-    if (!f) {
-	f = next_finfo();
-	finfo_new(f, oldpath, abspath, hash);
+    if (!*(char *) f) {
+	finfo_new(f);
 	record_file(f->outname, oldpath, abspath);
-	record_hash(f->outname, f->hash);
+	record_hash(f->outname, hash);
+	dup = strdup(key);
     } else {
-	free(oldpath);
-	free(abspath);
-	free(hash);
+	dup = key;		       /* We can reuse that */
     }
 
-    pi->entry_info = (void *) (f - finfo);
-    if (pi->entry_info == NULL)
-	error(EXIT_FAILURE, errno, "on handle_rename_entry absolutepath");
+    pi->entry_info = (void *) dup;
+
+    free(oldpath);
+    free(abspath);
+    free(hash);
 }
 
 static void
 handle_rename_exit(pid_t pid, PROCESS_INFO *pi, int newdirfd, char *newpath)
 {
-    FILE_INFO *from = finfo + (ptrdiff_t) pi->entry_info;
+    char *fromkey = (char *) pi->entry_info;
+    FILE_INFO *from = hashmap_insert(&finfo, fromkey);
+
+    /* The first SHA1_HEXBUF_LEN(excluding the null byte) bytes are the hash */
+    fromkey[SHA1_HEXBUF_LEN - 1] = 0;
+    char *hash = fromkey;	  /* readability */
 
     char *abspath = absolutepath(pid, newdirfd, newpath);
+    char *tokey = craft_key(abspath, hash);
 
-    FILE_INFO *to = next_finfo();
+    FILE_INFO *to = hashmap_insert(&finfo, tokey);
 
-    finfo_new(to, newpath, abspath, from->hash);
+    finfo_new(to);
     record_file(to->outname, newpath, abspath);
-    record_hash(to->outname, to->hash);
+    record_hash(to->outname, hash);
 
     record_rename(pi->outname, from->outname, to->outname);
+
+    free(newpath);
+    free(abspath);
+    /* This also frees fromkey, since they point to the same buffer */
+    free(hash);
 }
 
 static void
@@ -439,6 +436,7 @@ handle_syscall_exit(pid_t pid, PROCESS_INFO *pi,
     int flags;
     int dirfd;
     FILE_INFO *f;
+    FILE_WRITE *fw;
     int newdirfd;
     char *newpath;
 
@@ -472,21 +470,23 @@ handle_syscall_exit(pid_t pid, PROCESS_INFO *pi,
 	    // int close(int fd);
 	    fd = (int) entry->entry.args[0];
 
-	    f = pinfo_find_finfo(pi, fd);
+	    fw = pinfo_find_finfo(pi, fd);
+	    f = &(fw->f);
 
-	    if (f != NULL) {
-		f->hash = get_file_hash(f->abspath);
-		record_hash(f->outname, f->hash);
+	    if (fw != NULL) {
+		char *hash = get_file_hash(fw->abspath);
 
-		// Add it to global cache list
-		*next_finfo() = *f;
+		record_hash(f->outname, hash);
+
+		// Add it to global set
+		*hashmap_insert(&finfo, craft_key(fw->abspath, hash)) = *f;
 
 		// Remove the file from the process' list
-		for (int i = f - pi->finfo; i < pi->numfinfo; ++i) {
+		for (int i = fw - pi->finfo; i < pi->numfinfo; ++i) {
 		    pi->finfo[i] = pi->finfo[i + 1];
 		}
 
-		for (int i = f - pi->finfo; i < pi->numfinfo; ++i) {
+		for (int i = fw - pi->finfo; i < pi->numfinfo; ++i) {
 		    pi->fds[i] = pi->fds[i + 1];
 		}
 
@@ -499,6 +499,7 @@ handle_syscall_exit(pid_t pid, PROCESS_INFO *pi,
 	    path = pi->entry_info;
 
 	    handle_execve(pid, pi, AT_FDCWD, path);
+	    free(path);
 	    break;
 	case SYS_execveat:
 	    // int execveat(int dirfd, const char *pathname,
@@ -508,6 +509,7 @@ handle_syscall_exit(pid_t pid, PROCESS_INFO *pi,
 	    path = pi->entry_info;
 
 	    handle_execve(pid, pi, dirfd, path);
+	    free(path);
 	    break;
 	case SYS_rename:
 	    // int rename(const char *oldpath, const char *newpath);
@@ -650,8 +652,6 @@ tracer_main(pid_t pid, PROCESS_INFO *pi, char *path, char **envp)
 	    free(process_state->cmd_line);
 	    free(process_state->finfo);
 	    free(process_state->fds);
-
-	    int i = process_state - pinfo;
 
 	    for (int i = process_state - pinfo; i < numpinfo; ++i) {
 		pinfo[i] = pinfo[i + 1];

--- a/src/types.h
+++ b/src/types.h
@@ -16,19 +16,21 @@ SPDX-License-Identifier: LGPL-2.1-or-later
 #include        <linux/ptrace.h>
 
 /*
- * For each file, we keep its name/path
- * (the argument to the open(2) call that opened it,
- * whether it was opened for reading or for writing
- * (re-using the O_ flags),
- * and a hash of the contents.
- * Not all info is added at the same time.
+ * For each file, we keep its outname. 
  */
 typedef struct {
-    char *path;
-    char *abspath;
-    char *hash;
     char outname[16];
 } FILE_INFO;
+
+/*
+ * When a file is open for writing, we need to
+ * also store its abspath inside the process' list
+ * so that we can compute its hash when it's closed.
+ */
+typedef struct {
+    FILE_INFO f;
+    char *abspath;
+} FILE_WRITE;
 
 /*
  * For each (sub-)process we keep its pid,
@@ -41,7 +43,7 @@ typedef struct {
     char outname[16];
     char *cmd_line;
     int *fds;
-    FILE_INFO *finfo;
+    FILE_WRITE *finfo;
     int numfinfo;
     int finfo_size;
     struct ptrace_syscall_info state;


### PR DESCRIPTION
I implemented a simple hashmap that resolves conflicts using open addressing linear probing. Using the first string hashing algorithm I found! I used `&` to bound the output using power of two sizes for the underlying array.

I didn't make any attempts to make the interface generic other than using `typedef`s here and there.

While it is a "naive" hashtable(If i ever was to optimize it I'd using something better than a plain `&` and probably a robinhood hashing instead) running the tests yields adequate results, in fact the complexity no longer scales with array size! With `hashmap_insert(3)`(the one and only function i needed to implement) taking up only 0.02% of the total runtime(previously it could be as high as 10% given a "big" build, for example, the linux kernel with all config options set to `no`).

Since I've made plenty of changes, I'd feel better if we were to instead use a testing branch for now.
I am currently compiling `wine`, a project that previously took about four hours to compile on my machine while build_recorder wrapped it. I will post the two `callgrind` outputs(before and after the hashmap, aka `main` branch vs this PR `hashtable` branch) once it's complete!

