### PR TITLE
Make types.h platform agnostic by substituting ptrace_syscall_info struct with just the system call number and its arguments.

### DIFF
--- a/src/tracer.c
+++ b/src/tracer.c
@@ -391,17 +391,16 @@ handle_create_process(PROCESS_INFO *pi, pid_t child)
 }
 
 static void
-handle_syscall_entry(pid_t pid, PROCESS_INFO *pi,
-		     const struct ptrace_syscall_info *entry)
+handle_syscall_entry(pid_t pid, PROCESS_INFO *pi)
 {
     int olddirfd;
     char *oldpath;
 
-    switch (entry->entry.nr) {
+    switch (pi->nr) {
 #ifdef HAVE_SYS_RENAME
 	case SYS_rename:
 	    // int rename(const char *oldpath, const char *newpath);
-	    oldpath = get_str_from_process(pid, (void *) entry->entry.args[0]);
+	    oldpath = get_str_from_process(pid, (void *) pi->args[0]);
 	    handle_rename_entry(pid, pi, AT_FDCWD, oldpath);
 	    break;
 #endif
@@ -409,8 +408,8 @@ handle_syscall_entry(pid_t pid, PROCESS_INFO *pi,
 	case SYS_renameat:
 	    // int renameat(int olddirfd, const char *oldpath, int newdirfd,
 	    // const char *newpath);
-	    olddirfd = entry->entry.args[0];
-	    oldpath = get_str_from_process(pid, (void *) entry->entry.args[1]);
+	    olddirfd = pi->args[0];
+	    oldpath = get_str_from_process(pid, (void *) pi->args[1]);
 	    handle_rename_entry(pid, pi, olddirfd, oldpath);
 	    break;
 #endif
@@ -418,32 +417,28 @@ handle_syscall_entry(pid_t pid, PROCESS_INFO *pi,
 	case SYS_renameat2:
 	    // int renameat2(int olddirfd, const char *oldpath, int newdirfd,
 	    // const char *newpath, unsigned int flags);
-	    olddirfd = entry->entry.args[0];
-	    oldpath = get_str_from_process(pid, (void *) entry->entry.args[1]);
+	    olddirfd = pi->args[0];
+	    oldpath = get_str_from_process(pid, (void *) pi->args[1]);
 	    handle_rename_entry(pid, pi, olddirfd, oldpath);
 	    break;
 #endif
 #ifdef HAVE_SYS_EXECVE
 	case SYS_execve:
-	    pi->entry_info =
-		    get_str_from_process(pid, (void *) entry->entry.args[0]);
+	    pi->entry_info = get_str_from_process(pid, (void *) pi->args[0]);
 	    break;
 #endif
 #ifdef HAVE_SYS_EXECVEAT
 	case SYS_execveat:
-	    pi->entry_info =
-		    get_str_from_process(pid, (void *) entry->entry.args[1]);
+	    pi->entry_info = get_str_from_process(pid, (void *) pi->args[1]);
 	    break;
 #endif
     }
 }
 
 static void
-handle_syscall_exit(pid_t pid, PROCESS_INFO *pi,
-		    const struct ptrace_syscall_info *entry,
-		    const struct ptrace_syscall_info *exit)
+handle_syscall_exit(pid_t pid, PROCESS_INFO *pi, int64_t rval)
 {
-    if (exit->exit.rval < 0) {
+    if (rval < 0) {
 	return;			       // return on syscall failure
     }
 
@@ -455,13 +450,13 @@ handle_syscall_exit(pid_t pid, PROCESS_INFO *pi,
     int newdirfd;
     char *newpath;
 
-    switch (entry->entry.nr) {
+    switch (pi->nr) {
 #ifdef HAVE_SYS_OPEN
 	case SYS_open:
 	    // int open(const char *pathname, int flags, ...);
-	    fd = (int) exit->exit.rval;
-	    path = (void *) entry->entry.args[0];
-	    flags = (int) entry->entry.args[1];
+	    fd = (int) rval;
+	    path = (void *) pi->args[0];
+	    flags = (int) pi->args[1];
 
 	    handle_open(pid, pi, fd, AT_FDCWD, path, flags);
 	    break;
@@ -469,8 +464,8 @@ handle_syscall_exit(pid_t pid, PROCESS_INFO *pi,
 #ifdef HAVE_SYS_CREAT
 	case SYS_creat:
 	    // int creat(const char *pathname, ...);
-	    fd = (int) exit->exit.rval;
-	    path = (void *) entry->entry.args[0];
+	    fd = (int) rval;
+	    path = (void *) pi->args[0];
 
 	    handle_open(pid, pi, fd, AT_FDCWD, path,
 			O_CREAT | O_WRONLY | O_TRUNC);
@@ -479,10 +474,10 @@ handle_syscall_exit(pid_t pid, PROCESS_INFO *pi,
 #ifdef HAVE_SYS_OPENAT
 	case SYS_openat:
 	    // int openat(int dirfd, const char *pathname, int flags, ...);
-	    fd = (int) exit->exit.rval;
-	    dirfd = (int) entry->entry.args[0];
-	    path = (void *) entry->entry.args[1];
-	    flags = (int) entry->entry.args[2];
+	    fd = (int) rval;
+	    dirfd = (int) pi->args[0];
+	    path = (void *) pi->args[1];
+	    flags = (int) pi->args[2];
 
 	    handle_open(pid, pi, fd, dirfd, path, flags);
 	    break;
@@ -490,7 +485,7 @@ handle_syscall_exit(pid_t pid, PROCESS_INFO *pi,
 #ifdef HAVE_SYS_CLOSE
 	case SYS_close:
 	    // int close(int fd);
-	    fd = (int) entry->entry.args[0];
+	    fd = (int) pi->args[0];
 
 	    f = pinfo_find_finfo(pi, fd);
 
@@ -528,7 +523,7 @@ handle_syscall_exit(pid_t pid, PROCESS_INFO *pi,
 	    // int execveat(int dirfd, const char *pathname,
 	    // const char *const argv[], const char * const envp[],
 	    // int flags);
-	    dirfd = entry->entry.args[0];
+	    dirfd = pi->args[0];
 	    path = pi->entry_info;
 
 	    handle_execve(pid, pi, dirfd, path);
@@ -537,7 +532,7 @@ handle_syscall_exit(pid_t pid, PROCESS_INFO *pi,
 #ifdef HAVE_SYS_RENAME
 	case SYS_rename:
 	    // int rename(const char *oldpath, const char *newpath);
-	    newpath = get_str_from_process(pid, (void *) entry->entry.args[1]);
+	    newpath = get_str_from_process(pid, (void *) pi->args[1]);
 
 	    handle_rename_exit(pid, pi, AT_FDCWD, newpath);
 	    break;
@@ -546,8 +541,8 @@ handle_syscall_exit(pid_t pid, PROCESS_INFO *pi,
 	case SYS_renameat:
 	    // int renameat(int olddirfd, const char *oldpath, int newdirfd,
 	    // const char *newpath);
-	    newdirfd = entry->entry.args[2];
-	    newpath = get_str_from_process(pid, (void *) entry->entry.args[3]);
+	    newdirfd = pi->args[2];
+	    newpath = get_str_from_process(pid, (void *) pi->args[3]);
 
 	    handle_rename_exit(pid, pi, newdirfd, newpath);
 	    break;
@@ -556,8 +551,8 @@ handle_syscall_exit(pid_t pid, PROCESS_INFO *pi,
 	case SYS_renameat2:
 	    // int renameat2(int olddirfd, const char *oldpath, int newdirfd,
 	    // const char *newpath, unsigned int flags);
-	    newdirfd = entry->entry.args[2];
-	    newpath = get_str_from_process(pid, (void *) entry->entry.args[3]);
+	    newdirfd = pi->args[2];
+	    newpath = get_str_from_process(pid, (void *) pi->args[3]);
 
 	    handle_rename_exit(pid, pi, newdirfd, newpath);
 	    break;
@@ -565,19 +560,19 @@ handle_syscall_exit(pid_t pid, PROCESS_INFO *pi,
 #ifdef HAVE_SYS_FORK
 	case SYS_fork:
 	    // pid_t fork(void);
-	    handle_create_process(pi, exit->exit.rval);
+	    handle_create_process(pi, rval);
 	    break;
 #endif
 #ifdef HAVE_SYS_VFORK
 	case SYS_vfork:
 	    // pid_t vfork(void);
-	    handle_create_process(pi, exit->exit.rval);
+	    handle_create_process(pi, rval);
 	    break;
 #endif
 #ifdef HAVE_SYS_CLONE
 	case SYS_clone:
 	    // int clone(...);
-	    handle_create_process(pi, exit->exit.rval);
+	    handle_create_process(pi, rval);
 	    break;
 #endif
     }
@@ -632,12 +627,14 @@ tracer_main(pid_t pid, PROCESS_INFO *pi, char *path, char **envp)
 
 		    switch (info.op) {
 			case PTRACE_SYSCALL_INFO_ENTRY:
-			    process_state->state = info;
-			    handle_syscall_entry(pid, process_state, &info);
+			    process_state->nr = info.entry.nr;
+			    memcpy(process_state->args, info.entry.args,
+				   6 * sizeof (uint64_t));
+			    handle_syscall_entry(pid, process_state);
 			    break;
 			case PTRACE_SYSCALL_INFO_EXIT:
 			    handle_syscall_exit(pid, process_state,
-						&process_state->state, &info);
+						info.exit.rval);
 			    break;
 			default:
 			    error(EXIT_FAILURE, errno,

--- a/src/types.h
+++ b/src/types.h
@@ -11,9 +11,9 @@ SPDX-License-Identifier: LGPL-2.1-or-later
 #include <sys/stat.h>
 #include <fcntl.h>
 #include <unistd.h>
+#include <stdint.h>
 
 #include <sys/ptrace.h>
-#include        <linux/ptrace.h>
 
 /*
  * For each file, we keep its name/path
@@ -34,8 +34,8 @@ typedef struct {
  * For each (sub-)process we keep its pid,
  * the command line (including all the arguments)
  * the list of files that are currently open for writing,
- * and, while it's running, its current syscall
- * stop info struct.
+ * and, while it's running, its current syscall number
+ * and arguments.
  */
 typedef struct {
     char outname[16];
@@ -44,7 +44,8 @@ typedef struct {
     FILE_INFO *finfo;
     int numfinfo;
     int finfo_size;
-    struct ptrace_syscall_info state;
+    uint64_t nr;
+    uint64_t args[6];
     void *entry_info;
     char ignore_one_sigstop;
 } PROCESS_INFO;


### PR DESCRIPTION
We weren't using any of the rest anyways.

Signed-off-by: Fotios Valasiadis <fvalasiad@gmail.com>