### PR TITLE
Set output dir to top_builddir.

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -2,9 +2,9 @@
 # Copyright (C) 2023 Fotios Valasiadis
 # SPDX-License-Identifier: LGPL-2.1-or-later
 
-bin_PROGRAMS = build-recorder
+bin_PROGRAMS = $(top_builddir)/build-recorder
 
-build_recorder_SOURCES = \
+__top_builddir__build_recorder_SOURCES = \
 	hash.c \
 	main.c \
 	record.c \


### PR DESCRIPTION
That's to fix subdirectories expecting the executable to be at the build directory's toplevel.

Closes #216 